### PR TITLE
Ensure everything can be built from root on a fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 # This will build the docker image for ai-training-api
 .PHONY: build-ai-training-api
 build-ai-training-api:
+	$(MAKE) exe -C ai-training-api
 	docker build -t grafana/ai-training-api -f ./ai-training-api/Dockerfile .
+
+.PHONY: docker
+docker: build-ai-training-api
+	docker compose up

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ build-aitraining-app:
 .PHONY: docker
 docker: build-ai-training-api build-aitraining-app
 	docker compose up
+
+.PHONY: docker-down
+docker
+	docker compose down

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ build-ai-training-api:
 	$(MAKE) exe -C ai-training-api
 	docker build -t grafana/ai-training-api -f ./ai-training-api/Dockerfile .
 
+## Calls "mage" in the ai-training-app directory to build the app
+.phony: build-aitraining-app
+build-aitraining-app:
+	$(MAKE) && mage -v
+	cd grafana-aitraining-app && yarn install
+	cd grafana-aitraining-app && yarn build	
+
 .PHONY: docker
-docker: build-ai-training-api
+docker: build-ai-training-api build-aitraining-app
 	docker compose up

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build-ai-training-api:
 ## Calls "mage" in the ai-training-app directory to build the app
 .phony: build-aitraining-app
 build-aitraining-app:
-	$(MAKE) && mage -v
+	cd grafana-aitraining-app && mage -v
 	cd grafana-aitraining-app && yarn install
 	cd grafana-aitraining-app && yarn build	
 

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,5 @@ docker: build-ai-training-api build-aitraining-app
 	docker compose up
 
 .PHONY: docker-down
-docker
+docker-down:
 	docker compose down

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Layout is as follows:
 - `o11y/` is the python exporter
 - `ai-training-api/` contains the metadata (and maybe proxy) service and any necessary files for mysql (specifying database configuration, especially)
 - `grafana-aitraining-app/` contains the grafana plugin
+
+## Development
+Requires:
+- Python (3.8 or later)
+- Node (20 or later)
+- Go (1.22 or later)
+- Docker
+- Make
+
+Builds dev environment with "make docker"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Requires:
 - Node (20 or later)
 - Go (1.22 or later)
 - Docker
+- Yarn
 - Make
+- Mage
 
 Builds dev environment with "make docker"

--- a/ai-training-api/Makefile
+++ b/ai-training-api/Makefile
@@ -9,6 +9,10 @@ GOARCH ?= $(shell go env GOARCH)
 # These env variables should be in sync with the ones exported in the Dockerfile
 GO_OPT= -mod vendor -ldflags "-X main.Branch=$(BUILD_BRANCH) -X main.Revision=$(BUILD_COMMIT) -X main.Version=$(BUILD_VERSION)"
 
+.PHONY: vendor
+vendor:
+	go mod vendor
+
 .PHONY: exe
-exe:
+exe: vendor
 	GO111MODULE=on go build $(GO_OPT) -o ./dist $(BUILD_INFO) ./...

--- a/grafana-aitraining-app/package.json
+++ b/grafana-aitraining-app/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "yarn run lint --fix",
     "e2e": "yarn exec cypress install && yarn exec grafana-e2e run",
     "e2e:update": "yarn exec cypress install && yarn exec grafana-e2e run --update-screenshots",
-    "server": "docker compose up --build",
     "sign": "npx --yes @grafana/sign-plugin@latest"
   },
   "author": "Grafana labs",


### PR DESCRIPTION
This makes sure we can spin up a dev env after "git clone", if we have appropriate dependencies, with a single command.

We have ... a lot of build tools in this already and ideally we would maybe remove make, but getting mage to do the same job ended up being tricky.