### PR TITLE
Add Loki proxy and fix field names

### DIFF
--- a/ai-training-api/app/api_test.go
+++ b/ai-training-api/app/api_test.go
@@ -25,18 +25,18 @@ const (
 	listenPort    = 0
 
 	sampleProcessNestedJSON = `{
-		"metadata": {
+		"user_metadata": {
 			"key1": "value1"
 		}
 	}`
 	sampleProcessWithGroupNameJSON = `{
 		"group": "group1",
-		"metadata": {
+		"user_metadata": {
 			"key1": "value1"
 		}
 	}`
 	sampleUpdateMetadataJSON = `{
-		"metadata": {
+		"user_metadata": {
 			"key1": "completely_different_value",
 			"key2": "value2"
 		}
@@ -81,7 +81,7 @@ func NewTestApp(t *testing.T, logger log.Logger) *App {
 	logLevel.Set("debug")
 	logFormat := &promlog.AllowedFormat{}
 	logFormat.Set("logfmt")
-	testApp, err := New(listenAddress, listenPort, filepath.Join(t.TempDir(), "test.db"), db.SQLite, "0", &promlog.Config{Level: logLevel, Format: logFormat})
+	testApp, err := New(listenAddress, listenPort, filepath.Join(t.TempDir(), "test.db"), db.SQLite, "0", "", &promlog.Config{Level: logLevel, Format: logFormat})
 	require.NoError(t, err)
 	// Run the server in parallel
 	go testApp.Run()

--- a/ai-training-api/app/app.go
+++ b/ai-training-api/app/app.go
@@ -31,10 +31,20 @@ type App struct {
 	// The server instance.
 	server *server.Server
 
+	// Loki address to proxy logs.
+	lokiAddress string
+
 	logger log.Logger
 }
 
-func New(listenAddress string, listenPort int, databaseAddress string, databaseType string, constTenant string, promlogConfig *promlog.Config) (*App, error) {
+func New(
+	listenAddress string,
+	listenPort int,
+	databaseAddress string,
+	databaseType string,
+	constTenant string,
+	lokiAddress string,
+	promlogConfig *promlog.Config) (*App, error) {
 	// Initialize observability constructs.
 	logger := promlog.New(promlogConfig)
 
@@ -86,9 +96,10 @@ func New(listenAddress string, listenPort int, databaseAddress string, databaseT
 
 	// Create the App.
 	a := &App{
-		_db:    db,
-		server: s,
-		logger: logger,
+		_db:         db,
+		server:      s,
+		lokiAddress: lokiAddress,
+		logger:      logger,
 	}
 
 	sqlDB, err := db.DB()

--- a/ai-training-api/main.go
+++ b/ai-training-api/main.go
@@ -59,6 +59,10 @@ func run() int {
 			"const-tenant",
 			"A constant tenant to add to every request. Should only be used in development.",
 		).String()
+		lokiAddress = kingpin.Flag(
+			"loki-address",
+			"Loki address to send logs to.",
+		).Default("http://loki:3100/loki/api/v1/push").String()
 		// tenantOverridesFile = kingpin.Flag(
 		// 	"tenant-overrides-file",
 		// 	"Path to YAML file containing overrides per tenant.",
@@ -74,7 +78,7 @@ func run() int {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
-	a, err := app.New(*listenAddress, *listenPort, *databaseAddress, *databaseType, *constTenant, promlogConfig)
+	a, err := app.New(*listenAddress, *listenPort, *databaseAddress, *databaseType, *constTenant, *lokiAddress, promlogConfig)
 	if err != nil {
 		return 1
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,7 @@ services:
       - ./docker-compose/0-createdb.sql:/docker-entrypoint-initdb.d/0-createdb.sql
 
   ai-training-api:
-    build:
-      context: .
-      dockerfile: ai-training-api/Dockerfile
-      target: development
-      args:
-        BUILDKIT_INLINE_CACHE: "1"
+    image: grafana/ai-training-api:latest
     working_dir: /go/src/ai-training-api
     # use a different endpoint in the docker-compose environment so we can use air
     # which monitors files and automatically restarts the server when they change

--- a/o11y/o11y/_internal/client.py
+++ b/o11y/o11y/_internal/client.py
@@ -20,7 +20,7 @@ class Client:
         login_string = os.environ.get('GF_AI_TRAINING_CREDS')
         self.custom_logger = logging.getLogger(__name__ + "-ai-training-o11y-client")
         self.set_credentials(login_string)
-    
+
     def set_credentials(self, login_string):
 
         if not login_string or type(login_string) != str:
@@ -70,7 +70,7 @@ class Client:
         if response.status_code != 200:
             logging.error(f'Failed to register with error: {response.text}')
             return False
-        try: 
+        try:
             process_uuid = response.json()['data']['process_uuid']
         except:
             logging.error(f'Failed to register with error: {response.text}')
@@ -82,8 +82,8 @@ class Client:
                 url=f"{self.url}/api/v1/process/{self.process_uuid}/model-metrics",
                 tags={
                     # This specific label guarantees that these logs never collide with anything not from this exporter
-                    "grafana-aitraining-o11y-process-uuid": self.process_uuid,
-                    "log-type": "model-metric",
+                    "grafana_aitraining_o11y_process_uuid": self.process_uuid,
+                    "log_type": "model-metric",
                 },
                 # The LokiHandler doesn't currently allow the use of token auth, we're going to have to add it
                 # or write our own handler, which seems a lot less elegant
@@ -93,7 +93,7 @@ class Client:
             )
         )
         return True
-    
+
     # Update user_metadata information
     def update_metadata(self, process_uuid, user_metadata):
         if not process_uuid:
@@ -111,7 +111,7 @@ class Client:
             logging.error(f'Failed to update metadata: {response.text}')
             return False
         return True
-    
+
     # Report a state change to the process
     # POST /api/v1/process/{uuid}/state
     # Options are “succeeded” and “failed”
@@ -131,7 +131,7 @@ class Client:
             logging.error(f'Failed to report state: {response.text}')
             return False
         return True
-    
+
     def send_log(self, log):
         if not self.process_uuid:
             logging.error("No process registered, unable to send logs")


### PR DESCRIPTION
- Add `POST /api/v1/process/{uuid}/model-metrics` endpoint that forwards logs to Loki.
- Update field to check for metadata from `metadata` to `user_metadata`
- Update o11y client to use underscores instead of hyphens in tag names (`grafana_aitraining_o11y_process_uuid`, `log_type`)