### PR TITLE
Fix-api-errors

### DIFF
--- a/ai-training-api/app/api.go
+++ b/ai-training-api/app/api.go
@@ -50,6 +50,7 @@ func (a *App) registerNewProcess(tenantID string, req *http.Request) (interface{
 	process.ID = uuid.New()
 	process.TenantID = tenantID
 	process.StartTime = time.Now()
+	process.Status = "running"  // Set default status to "running"
 
 	// Store process in DB.
 	err := a.db(req.Context()).Model(&model.Process{}).Create(process).Error

--- a/ai-training-o11y.code-workspace
+++ b/ai-training-o11y.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "grafana-aitraining-app"
+		}
+	],
+	"settings": {}
+}

--- a/grafana-aitraining-app/src/hooks/useProcessQueries.tsx
+++ b/grafana-aitraining-app/src/hooks/useProcessQueries.tsx
@@ -11,11 +11,11 @@ const useProcessQueries = () => {
 
   const isReady = datasource.loading !== true;
 
-  const { selectedRows, appendResult, setQueryStatus } = useTrainingAppStore();
+  const { selectedRows, appendLokiResult: appendResult, setLokiQueryStatus } = useTrainingAppStore();
 
   const runQueries = async () => {
     console.log(`Starting all queries at ${new Date().toISOString()}`);
-    setQueryStatus('loading');
+    setLokiQueryStatus('loading');
   
     const queryPromises = selectedRows.map(async (processData, index) => {
       console.log(`Preparing query ${index} at ${new Date().toISOString()}`);
@@ -35,7 +35,7 @@ const useProcessQueries = () => {
   
       const query = {
         refId: 'A',
-        expr: `{job="o11y"} | process_uuid = \`${processData.process_uuid}\` |= \`\``,
+        expr: `{job="o11y"} | process_uuid = \`${processData.process_uuid}\``,
         queryType: 'range',
       };
 
@@ -63,10 +63,10 @@ const useProcessQueries = () => {
       console.log(`Awaiting all queries at ${new Date().toISOString()}`);
       await Promise.all(queryPromises);
       console.log(`All queries completed at ${new Date().toISOString()}`);
-      setQueryStatus('success');
+      setLokiQueryStatus('success');
     } catch (error) {
       console.error(`Error running queries at ${new Date().toISOString()}:`, error);
-      setQueryStatus('error');
+      setLokiQueryStatus('error');
     }
   };
 

--- a/grafana-aitraining-app/src/pages/Home/components/GraphsTab.tsx
+++ b/grafana-aitraining-app/src/pages/Home/components/GraphsTab.tsx
@@ -9,54 +9,60 @@ interface GraphsProps {
 }
 
 export const GraphsTab: React.FC<GraphsProps> = ({ rows }) => {
-  const { queryStatus, queryData, organizedData, resetResults, setOrganizedData } = useTrainingAppStore();
+  const {
+    lokiQueryStatus,
+    lokiQueryData,
+    organizedLokiData,
+    resetLokiResults,
+    setOrganizedLokiData
+  } = useTrainingAppStore();
   const { isReady, runQueries } = useProcessQueries();
   const shouldRunQueries = useRef(true);
 
   useEffect(() => {
     if (isReady && rows.length > 0 && shouldRunQueries.current) {
       shouldRunQueries.current = false;
-      resetResults();
+      resetLokiResults();
       runQueries();
     }
-  }, [isReady, rows, resetResults, runQueries]);
+  }, [isReady, rows, resetLokiResults, runQueries]);
 
   useEffect(() => {
     shouldRunQueries.current = true;
   }, [rows]);
 
   useEffect(() => {
-    if (queryStatus === 'success' && Object.keys(queryData).length > 0) {
-      const organized = reshapeModelMetrics(queryData);
-      setOrganizedData(organized);
+    if (lokiQueryStatus === 'success' && Object.keys(lokiQueryData).length > 0) {
+      const organized = reshapeModelMetrics(lokiQueryData);
+      setOrganizedLokiData(organized);
     }
-  }, [queryStatus, queryData, setOrganizedData]);
+  }, [lokiQueryStatus, lokiQueryData, setOrganizedLokiData]);
 
   if (!isReady) {
     return <div>Loading...</div>;
   }
 
-  if (queryStatus === 'loading') {
+  if (lokiQueryStatus === 'loading') {
     return (
       <div>
         Running...
-        <button onClick={() => { resetResults(); shouldRunQueries.current = true; }}>Reset Results</button>
+        <button onClick={() => { resetLokiResults(); shouldRunQueries.current = true; }}>Reset Results</button>
       </div>
     );
   }
 
-  if (!organizedData) {
+  if (!organizedLokiData) {
     return <div>No data</div>;
   }
 
   return (
     <div>
-      <button onClick={() => { resetResults(); shouldRunQueries.current = true; }}>Reset Results</button>
+      <button onClick={() => { resetLokiResults(); shouldRunQueries.current = true; }}>Reset Results</button>
       
       <div style={{ marginBottom: '20px' }}>
         <h3>Organized Data:</h3>
-        {organizedData ? (
-          <pre>{JSON.stringify(organizedData, null, 2)}</pre>
+        {organizedLokiData ? (
+          <pre>{JSON.stringify(organizedLokiData, null, 2)}</pre>
         ) : (
           <p>No organized data available</p>
         )}
@@ -64,10 +70,10 @@ export const GraphsTab: React.FC<GraphsProps> = ({ rows }) => {
 
       <div style={{ marginBottom: '20px' }}>
         <h3>Query Data:</h3>
-        {Object.keys(queryData).map((key) => (
+        {Object.keys(lokiQueryData).map((key) => (
           <React.Fragment key={key}>
             <h4>Results for process: {key}</h4>
-            <pre>{JSON.stringify(queryData[key].lokiData?.series[0].fields, null, 2)}</pre>
+            <pre>{JSON.stringify(lokiQueryData[key].lokiData?.series[0].fields, null, 2)}</pre>
           </React.Fragment>
         ))}
       </div>

--- a/grafana-aitraining-app/src/pages/Home/components/TableTab.tsx
+++ b/grafana-aitraining-app/src/pages/Home/components/TableTab.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { RowData } from 'utils/state';
-
-// import { Loki } from 'components/Datasources/Loki';
-
+import { RowData, QueryStatus } from 'utils/state';
 
 interface TableTabProps {
+  processQueryStatus: QueryStatus;
   rows: RowData[];
   isSelected: boolean[];
   setIsSelected: (index: number, value: boolean) => void;
@@ -13,19 +11,20 @@ interface TableTabProps {
 }
 
 export const TableTab: React.FC<TableTabProps> = ({
+  processQueryStatus,
   rows,
   isSelected,
   setIsSelected,
   addSelectedRow,
   removeSelectedRow,
 }: TableTabProps) => {
-
   // Get the unique column names from the data
   const columnNames = Array.from(new Set(rows.flatMap(Object.keys)));
 
   return (
     <div>
       <h2>Table</h2>
+      {processQueryStatus === 'success' || <div>processQueryStatus</div>}
       <table style={styles.table}>
         <thead>
           <tr>
@@ -70,14 +69,14 @@ export const TableTab: React.FC<TableTabProps> = ({
 
 const styles = {
   table: {
-    borderCollapse: 'collapse' as 'collapse', // This is now a specific string value
+    borderCollapse: 'collapse' as 'collapse',
     width: '100%',
   },
   th: {
     backgroundColor: 'gray',
     border: '1px solid black',
     padding: '10px',
-    textAlign: 'center' as 'center', // This is now a specific string value
+    textAlign: 'center' as 'center',
   },
   tr: {
     borderBottom: '1px solid #ddd',
@@ -85,6 +84,21 @@ const styles = {
   td: {
     border: '1px solid #ddd',
     padding: '8px',
+  },
+  statusMessage: {
+    padding: '10px',
+    marginBottom: '10px',
+    backgroundColor: '#e6f3ff',
+    border: '1px solid #b8daff',
+    borderRadius: '4px',
+  },
+  errorMessage: {
+    padding: '10px',
+    marginBottom: '10px',
+    backgroundColor: '#f8d7da',
+    border: '1px solid #f5c6cb',
+    borderRadius: '4px',
+    color: '#721c24',
   },
 };
 

--- a/grafana-aitraining-app/src/utils/state.ts
+++ b/grafana-aitraining-app/src/utils/state.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { PanelData } from '@grafana/data';
 
 export type ProcessStatus = 'empty' | 'running' | 'finished' | 'crashed' | 'timed out';
-type QueryStatus =
+export type QueryStatus =
   | 'idle'
   | 'loading'
   | 'success'
@@ -29,6 +29,10 @@ interface TrainingAppState {
   tab: 'table' | 'graphs';
   setTab: (tab: 'table' | 'graphs') => void;
 
+  // Process table query state
+  processesQueryStatus: QueryStatus;
+  setProcessesQueryStatus: (status: QueryStatus) => void;
+
   // Rendered rows state
   renderedRows: RowData[];
   isSelected: boolean[];
@@ -42,21 +46,24 @@ interface TrainingAppState {
   addSelectedRow: (row: RowData) => void;
   removeSelectedRow: (processUuid: string) => void;
 
-  // Query result state
-  queryStatus: QueryStatus;
-  queryData: Record<string, QueryResultData>;
-  resetResults: () => void;
-  appendResult: (processData: RowData, result: PanelData | undefined) => void;
-  setQueryStatus: (status: QueryStatus) => void;
+  // Loki query result state
+  lokiQueryStatus: QueryStatus;
+  lokiQueryData: Record<string, QueryResultData>;
+  resetLokiResults: () => void;
+  appendLokiResult: (processData: RowData, result: PanelData | undefined) => void;
+  setLokiQueryStatus: (status: QueryStatus) => void;
 
-  organizedData: any; // Add the organizedData property
-  setOrganizedData: (data: any) => void; // Add the setOrganizedData function
+  organizedLokiData: any; // Add the organizedData property
+  setOrganizedLokiData: (data: any) => void; // Add the setOrganizedData function
 }
 
 export const useTrainingAppStore = create<TrainingAppState>()((set) => ({
   // Tab state
   tab: 'table',
   setTab: (tab) => set(() => ({ tab })),
+
+  processesQueryStatus: 'idle',
+  setProcessesQueryStatus: (status: QueryStatus) => set(() => ({ processesQueryStatus: status })),
 
   // Rendered rows state
   renderedRows: [],
@@ -109,14 +116,14 @@ export const useTrainingAppStore = create<TrainingAppState>()((set) => ({
     }),
 
   // Query result state
-  queryData: {},
-  queryStatus: 'idle',
-  resetResults: () => set(() => ({ queryStatus: 'idle', queryData: {} })),
-  appendResult: (processData, result) =>
+  lokiQueryData: {},
+  lokiQueryStatus: 'idle',
+  resetLokiResults: () => set(() => ({ lokiQueryStatus: 'idle', lokiQueryData: {} })),
+  appendLokiResult: (processData, result) =>
     set((state) => ({
-      queryData: { ...state.queryData, [processData.process_uuid]: { processData, lokiData: result } },
+      lokiQueryData: { ...state.lokiQueryData, [processData.process_uuid]: { processData, lokiData: result } },
     })),
-  setQueryStatus: (status: QueryStatus) => set(() => ({ queryStatus: status })),
-  organizedData: {},
-  setOrganizedData: (data) => set((state) => ({ ...state, organizedData: data })), // Define the setOrganizedData function
+  setLokiQueryStatus: (status: QueryStatus) => set(() => ({ lokiQueryStatus: status })),
+  organizedLokiData: {},
+  setOrganizedLokiData: (data) => set((state) => ({ ...state, organizedLokiData: data })), // Define the setOrganizedData function
 }));


### PR DESCRIPTION
Because new processes were not registered as 'running', setting the loki query to end at current time if they were 'running' was not happening. Since the end times are also not set this caused an error. This fixes that, and improves query error handling on the frontend generally.