### PR TITLE
Fix release plugin to follow a normal workflow dispatch workflow

### DIFF
--- a/.github/workflows/build-plugin/action.yml
+++ b/.github/workflows/build-plugin/action.yml
@@ -2,6 +2,9 @@ name: "Grafana Build Plugin"
 description: "Builds a Grafana plugin"
 
 outputs:
+  version:
+    description: "The version of the plugin."
+    value: ${{ steps.metadata.outputs.plugin-version }}
   archive:
     description: "The path to the plugin archive (zip)."
     value: ${{ steps.metadata.outputs.archive }}
@@ -123,7 +126,6 @@ runs:
         echo "archive-sha1sum=${GRAFANA_PLUGIN_ARTIFACT_SHA1SUM}" >> $GITHUB_OUTPUT
         echo "archive-url=https://github.com/${{ github.repository }}/releases/download/v${{ steps.metadata.outputs.plugin-version }}/${{ steps.metadata.outputs.archive }}"
         echo "archive-sha1sum-url=(https://github.com/${{ github.repository }}/releases/download/v${{ steps.metadata.outputs.plugin-version }}/${{ steps.metadata.outputs.archive-sha1sum }}"
-        echo "github-tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
@@ -132,11 +134,6 @@ runs:
       run: |
         awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
         echo "path=release_notes.md" >> $GITHUB_OUTPUT
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-
-    - name: Check package version
-      run: if [ "v${{ steps.metadata.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.metadata.outputs.plugin-version }} \033[0m\n"; exit 1; fi
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,8 +1,16 @@
 name: Release
+
 on:
-  push:
-    tags:
-      - "v*" # Run workflow on version tags, e.g. v1.0.0.
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish plugin'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 permissions:
   contents: write
@@ -13,6 +21,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Build Plugin
         id: build_plugin
         uses: ./.github/workflows/build-plugin
@@ -20,14 +29,12 @@ jobs:
           policy-token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
           working-directory: grafana-aitraining-app
 
-      - name: Get version from tag
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
+        # This one is untested because the plugin is still way too alpha to publish.
       - name: Publish new plugin version on grafana.com
+        if: inputs.publish == true
         env:
           GCOM_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          VERSION: ${{ steps.build_plugin.outputs.version }}
           ARCHIVE_URL: ${{ steps.build_plugin.outputs.archive-url }}
           ARCHIVE_SHA1SUM_URL: ${{ steps.build_plugin.outputs.archive-sha1sum-url }}
         run: |


### PR DESCRIPTION
Existing workflow required pushing tags, didn't have an option to bypass publishing on grafana.com, this fixes those things