### PR TITLE
Add ready handler and loki tenant ID flag

### DIFF
--- a/ai-training-api/app/api.go
+++ b/ai-training-api/app/api.go
@@ -50,7 +50,7 @@ func (a *App) registerNewProcess(tenantID string, req *http.Request) (interface{
 	process.ID = uuid.New()
 	process.TenantID = tenantID
 	process.StartTime = time.Now()
-	process.Status = "running"  // Set default status to "running"
+	process.Status = "running" // Set default status to "running"
 
 	// Store process in DB.
 	err := a.db(req.Context()).Model(&model.Process{}).Create(process).Error
@@ -424,6 +424,9 @@ func (a *App) addModelMetrics(tenantID string, req *http.Request) (interface{}, 
 		return nil, middleware.ErrBadRequest(err)
 	}
 	lokiReq.Header.Set("Content-Type", "application/json")
+	if a.lokiTenant != "" {
+		lokiReq.Header.Set("X-Scope-OrgID", a.lokiTenant)
+	}
 	lokiResp, err := httpClient.Do(lokiReq)
 	if err != nil {
 		return nil, middleware.ErrBadRequest(err)

--- a/ai-training-api/main.go
+++ b/ai-training-api/main.go
@@ -63,10 +63,10 @@ func run() int {
 			"loki-address",
 			"Loki address to send logs to.",
 		).Default("http://loki:3100/loki/api/v1/push").String()
-		// tenantOverridesFile = kingpin.Flag(
-		// 	"tenant-overrides-file",
-		// 	"Path to YAML file containing overrides per tenant.",
-		// ).ExistingFile()
+		lokiTenantID = kingpin.Flag(
+			"loki-tenant-id",
+			"Loki tenant ID to send logs to.",
+		).Default("").String()
 	)
 
 	// Allow configuration to be specified via environment variables.
@@ -78,7 +78,15 @@ func run() int {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
-	a, err := app.New(*listenAddress, *listenPort, *databaseAddress, *databaseType, *constTenant, *lokiAddress, promlogConfig)
+	a, err := app.New(
+		*listenAddress,
+		*listenPort,
+		*databaseAddress,
+		*databaseType,
+		*constTenant,
+		*lokiAddress,
+		*lokiTenantID,
+		promlogConfig)
 	if err != nil {
 		return 1
 	}


### PR DESCRIPTION
Two changes in this PR:
- Adding a `/ready` handler so kubernetes knows when a pod is ready.
- Adding a flag for Loki tenant ID to forward logs to from the backend service. I believe just setting the Loki tenant ID on the request as a `X-Scope-OrgID` header should be enough if we route it to the loki distributor directly. 

part of https://github.com/grafana/ai-training-o11y/issues/45