### PR TITLE
Remove restart config from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
 
   mimir:
     image: grafana/mimir:2.12.0
-    restart: on-failure
     command:
       - -config.file=/etc/mimir-config/mimir.yml
     volumes:
@@ -59,13 +58,11 @@ services:
 
   loki:
     image: grafana/loki:3.0.0
-    restart: on-failure
     ports:
       - "3100:3100"
 
   tempo:
     image: grafana/tempo:2.4.1
-    restart: on-failure
     command:
       - "-storage.trace.backend=local"                  # tell tempo where to permanently put traces
       - "-storage.trace.local.path=/tmp/tempo/traces"
@@ -78,7 +75,6 @@ services:
 
   pyroscope:
     image: grafana/pyroscope:1.5.0
-    restart: on-failure
     ports:
       - "4040:4040"
 


### PR DESCRIPTION
This should fix some build problems we see where images persist after docker-compose is killed and has very little downside, if any.