### PR TITLE
fix: Pinning version of go air 

### DIFF
--- a/ai-training-api/Dockerfile
+++ b/ai-training-api/Dockerfile
@@ -28,7 +28,7 @@ COPY --link ai-training-api ./
 
 FROM prep AS development
 
-RUN --mount=type=cache,id=go-cache-ai-training-api,target=/opt/go go install github.com/air-verse/air@latest
+RUN --mount=type=cache,id=go-cache-ai-training-api,target=/opt/go go install github.com/air-verse/air@v1.52.3
 
 FROM prep as build
 


### PR DESCRIPTION
Running `make docker` was failing due to an unmet dependency in latest for go air. 

Pinning the version for now, as i am not sure what will change if we upgrade go within the container.

