### PR TITLE
Sandersaarond/mysql model metrics

### DIFF
--- a/ai-training-api/Dockerfile
+++ b/ai-training-api/Dockerfile
@@ -28,7 +28,8 @@ COPY --link ai-training-api ./
 
 FROM prep AS development
 
-RUN --mount=type=cache,id=go-cache-ai-training-api,target=/opt/go go install github.com/air-verse/air@latest
+# Air fixed at 1.52.3 because 1.60.0 would force upgrading go to 1.23 and this is easier
+RUN --mount=type=cache,id=go-cache-ai-training-api,target=/opt/go go install github.com/air-verse/air@v1.52.3
 
 FROM prep as build
 

--- a/ai-training-api/app/api.go
+++ b/ai-training-api/app/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -393,108 +392,6 @@ func (a *App) deleteGroup(tenantID string, req *http.Request) (interface{}, erro
 
 	level.Info(a.logger).Log("msg", "deleted group", "tenantID", tenantID, "group_id", groupId)
 	return nil, err
-}
-
-func (a *App) addModelMetrics(tenantID string, req *http.Request) (interface{}, error) {
-    // Extract ProcessID from URL path
-    vars := mux.Vars(req)
-    processIDStr, ok := vars["id"]
-    if !ok {
-        return nil, middleware.ErrBadRequest(fmt.Errorf("process ID not provided in URL"))
-    }
-
-    // Parse ProcessID to UUID
-    processID, err := uuid.Parse(processIDStr)
-    if err != nil {
-        return nil, middleware.ErrBadRequest(fmt.Errorf("invalid process ID: %w", err))
-    }
-
-    // Validate ProcessID exists
-    var process model.Process
-    if err := a.db(req.Context()).First(&process, "id = ?", processID).Error; err != nil {
-        if errors.Is(err, gorm.ErrRecordNotFound) {
-            return nil, middleware.ErrNotFound(fmt.Errorf("process not found"))
-        }
-        return nil, fmt.Errorf("error checking process: %w", err)
-    }
-
-    // Parse request body
-    var metricsData []struct {
-        MetricName string `json:"metric_name"`
-        StepName   string `json:"step_name"`
-        Points     []struct {
-            Step  uint32 `json:"step"`
-            Value string `json:"value"`
-        } `json:"points"`
-    }
-
-    if err := json.NewDecoder(req.Body).Decode(&metricsData); err != nil {
-        return nil, middleware.ErrBadRequest(err)
-    }
-
-    // Convert tenantID to uint64 for StackID
-    stackID, err := strconv.ParseUint(tenantID, 10, 64)
-    if err != nil {
-        return nil, middleware.ErrBadRequest(fmt.Errorf("invalid tenant ID: %w", err))
-    }
-
-    var createdMetrics []model.ModelMetrics
-
-    // Start a transaction
-    tx := a.db(req.Context()).Begin()
-    if tx.Error != nil {
-        return nil, fmt.Errorf("error starting transaction: %w", tx.Error)
-    }
-
-    for _, metricData := range metricsData {
-        for _, point := range metricData.Points {
-            metric := model.ModelMetrics{
-                StackID:     stackID,
-                ProcessID:   processID,
-                MetricName:  metricData.MetricName,
-                StepName:    metricData.StepName,
-                Step:        point.Step,
-                MetricValue: point.Value,
-            }
-
-            // Validate fields
-            if err := validateModelMetric(&metric); err != nil {
-                tx.Rollback()
-                return nil, middleware.ErrBadRequest(err)
-            }
-
-            // Save to database
-            if err := tx.Create(&metric).Error; err != nil {
-                tx.Rollback()
-                return nil, fmt.Errorf("error creating model metric: %w", err)
-            }
-
-            createdMetrics = append(createdMetrics, metric)
-        }
-    }
-
-    // Commit the transaction
-    if err := tx.Commit().Error; err != nil {
-        return nil, fmt.Errorf("error committing transaction: %w", err)
-    }
-
-    return createdMetrics, nil
-}
-
-func validateModelMetric(m *model.ModelMetrics) error {
-    if len(m.MetricName) == 0 || len(m.MetricName) > 32 {
-        return fmt.Errorf("metric name must be between 1 and 32 characters")
-    }
-    if len(m.StepName) == 0 || len(m.StepName) > 32 {
-        return fmt.Errorf("step name must be between 1 and 32 characters")
-    }
-    if m.Step == 0 {
-        return fmt.Errorf("step must be a positive number")
-    }
-    if len(m.MetricValue) == 0 || len(m.MetricValue) > 64 {
-        return fmt.Errorf("metric value must be between 1 and 64 characters")
-    }
-    return nil
 }
 
 func namedParam(req *http.Request, name string) string {

--- a/ai-training-api/app/app.go
+++ b/ai-training-api/app/app.go
@@ -70,16 +70,24 @@ func New(
 		return nil, fmt.Errorf("error migrating Process table: %w", err)
 	}
 	level.Info(logger).Log("msg", "checking tables", "process_table_exists", db.Migrator().HasTable(&model.Process{}))
+
 	err = db.AutoMigrate(&model.Group{})
 	if err != nil {
 		return nil, fmt.Errorf("error migrating Group table: %w", err)
 	}
 	level.Info(logger).Log("msg", "checking tables", "group_table_exists", db.Migrator().HasTable(&model.Group{}))
+
 	err = db.AutoMigrate(&model.MetadataKV{})
 	if err != nil {
 		return nil, fmt.Errorf("error migrating MetadataKV table: %w", err)
 	}
 	level.Info(logger).Log("msg", "checking tables", "metadata_kv_table_exists", db.Migrator().HasTable(&model.MetadataKV{}))
+
+	err = db.AutoMigrate(&model.ModelMetrics{})
+	if err != nil {
+		return nil, fmt.Errorf("error migrating ModelMetrics table: %w", err)
+	}
+	level.Info(logger).Log("msg", "checking tables", "model_metrics_table_exists", db.Migrator().HasTable(&model.MetadataKV{}))
 
 	// Create server and router.
 	serverLogLevel := &dskit_log.Level{}

--- a/ai-training-api/app/model_metrics.go
+++ b/ai-training-api/app/model_metrics.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"gorm.io/gorm"
+
+	"github.com/grafana/ai-training-o11y/ai-training-api/middleware"
+	"github.com/grafana/ai-training-o11y/ai-training-api/model"
+)
+
+type modelMetricsRequest struct {
+	MetricName string `json:"metric_name"`
+	StepName   string `json:"step_name"`
+	Points     []struct {
+		Step  uint32 `json:"step"`
+		Value string `json:"value"`
+	} `json:"points"`
+}
+
+func (a *App) addModelMetrics(tenantID string, req *http.Request) (interface{}, error) {
+	// Extract and validate ProcessID
+	processID, err := extractAndValidateProcessID(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate ProcessID exists
+	if err := a.validateProcessExists(req.Context(), processID); err != nil {
+		return nil, err
+	}
+
+	// Parse and validate the request body
+	metricsData, err := parseAndValidateModelMetricsRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert tenantID to uint64 for StackID
+	stackID, err := strconv.ParseUint(tenantID, 10, 64)
+	if err != nil {
+		return nil, middleware.ErrBadRequest(fmt.Errorf("invalid tenant ID: %w", err))
+	}
+
+	createdMetrics, err := a.saveModelMetrics(req.Context(), stackID, processID, metricsData)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdMetrics, nil
+}
+
+func extractAndValidateProcessID(req *http.Request) (uuid.UUID, error) {
+    vars := mux.Vars(req)
+    if vars == nil {
+        return uuid.Nil, fmt.Errorf("mux.Vars(req) returned nil")
+    }
+
+    processIDStr, ok := vars["id"]
+    if !ok {
+        return uuid.Nil, middleware.ErrBadRequest(fmt.Errorf("process ID not provided in URL"))
+    }
+
+    // This case handles when the ID is provided in the URL but is empty
+    if processIDStr == "" {
+        return uuid.Nil, middleware.ErrBadRequest(fmt.Errorf("process ID is empty"))
+    }
+
+    processID, err := uuid.Parse(processIDStr)
+    if err != nil {
+        return uuid.Nil, middleware.ErrBadRequest(fmt.Errorf("invalid process ID: %w", err))
+    }
+
+    return processID, nil
+}
+
+func (a *App) validateProcessExists(ctx context.Context, processID uuid.UUID) error {
+	var process model.Process
+	if err := a.db(ctx).First(&process, "id = ?", processID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return middleware.ErrNotFound(fmt.Errorf("process not found"))
+		}
+		return fmt.Errorf("error checking process: %w", err)
+	}
+	return nil
+}
+
+func parseAndValidateModelMetricsRequest(req *http.Request) ([]modelMetricsRequest, error) {
+	var metricsData []modelMetricsRequest
+
+	if err := json.NewDecoder(req.Body).Decode(&metricsData); err != nil {
+		return nil, middleware.ErrBadRequest(err)
+	}
+
+	for _, metric := range metricsData {
+		if err := validateModelMetricRequest(&metric); err != nil {
+			return nil, middleware.ErrBadRequest(err)
+		}
+	}
+
+	return metricsData, nil
+}
+
+func validateModelMetricRequest(m *modelMetricsRequest) error {
+	if len(m.MetricName) == 0 || len(m.MetricName) > 32 {
+		return fmt.Errorf("metric name must be between 1 and 32 characters")
+	}
+	if len(m.StepName) == 0 || len(m.StepName) > 32 {
+		return fmt.Errorf("step name must be between 1 and 32 characters")
+	}
+	for _, point := range m.Points {
+		if point.Step == 0 {
+			return fmt.Errorf("step must be a positive number")
+		}
+		if len(point.Value) == 0 || len(point.Value) > 64 {
+			return fmt.Errorf("metric value must be between 1 and 64 characters")
+		}
+	}
+	return nil
+}
+
+func (a *App) saveModelMetrics(ctx context.Context, stackID uint64, processID uuid.UUID, metricsData []modelMetricsRequest) ([]model.ModelMetrics, error) {
+	var createdMetrics []model.ModelMetrics
+
+	// Start a transaction
+	tx := a.db(ctx).Begin()
+	if tx.Error != nil {
+		return nil, fmt.Errorf("error starting transaction: %w", tx.Error)
+	}
+
+	for _, metricData := range metricsData {
+		for _, point := range metricData.Points {
+			metric := model.ModelMetrics{
+				StackID:     stackID,
+				ProcessID:   processID,
+				MetricName:  metricData.MetricName,
+				StepName:    metricData.StepName,
+				Step:        point.Step,
+				MetricValue: point.Value,
+			}
+
+			// Save to database
+			if err := tx.Create(&metric).Error; err != nil {
+				tx.Rollback()
+				return nil, fmt.Errorf("error creating model metric: %w", err)
+			}
+
+			createdMetrics = append(createdMetrics, metric)
+		}
+	}
+
+	// Commit the transaction
+	if err := tx.Commit().Error; err != nil {
+		return nil, fmt.Errorf("error committing transaction: %w", err)
+	}
+
+	return createdMetrics, nil
+}

--- a/ai-training-api/app/model_metrics_test.go
+++ b/ai-training-api/app/model_metrics_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/grafana/ai-training-o11y/ai-training-api/model"
+)
+
+type testApp struct {
+	App
+}
+
+func (a *testApp) db(ctx context.Context) *gorm.DB {
+	return a.App._db
+}
+
+func setupTestDB(t *testing.T) (*gorm.DB, func()) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+
+	err = db.AutoMigrate(&model.Process{}, &model.ModelMetrics{})
+	require.NoError(t, err)
+
+	return db, func() {
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.Close()
+	}
+}
+
+func TestExtractAndValidateProcessID(t *testing.T) {
+    tests := []struct {
+        name           string
+        url            string
+        expectedID     uuid.UUID
+        expectedErrMsg string
+    }{
+        {
+            name:       "Valid UUID",
+            url:        "/process/123e4567-e89b-12d3-a456-426614174000/model-metrics",
+            expectedID: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+        },
+        {
+            name:           "Invalid UUID",
+            url:            "/process/invalid-uuid/model-metrics",
+            expectedErrMsg: "invalid process ID",
+        },
+        {
+            name:           "Empty ID",
+            url:            "/process//model-metrics",
+            expectedErrMsg: "process ID is empty",
+        },
+        {
+            name:           "No ID in URL",
+            url:            "/process/model-metrics",
+            expectedErrMsg: "process ID not provided in URL",
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            router := mux.NewRouter()
+            router.HandleFunc("/process/{id}/model-metrics", func(w http.ResponseWriter, r *http.Request) {
+                processID, err := extractAndValidateProcessID(r)
+                
+                if tt.expectedErrMsg != "" {
+                    assert.Error(t, err)
+                    assert.Contains(t, err.Error(), tt.expectedErrMsg)
+                } else {
+                    assert.NoError(t, err)
+                    assert.Equal(t, tt.expectedID, processID)
+                }
+            }).Methods("POST")
+
+            req, err := http.NewRequest("POST", tt.url, nil)
+            if err != nil {
+                t.Fatalf("Failed to create request: %v", err)
+            }
+
+            rr := httptest.NewRecorder()
+            router.ServeHTTP(rr, req)
+        })
+    }
+}
+
+func TestValidateProcessExists(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	if db == nil {
+		t.Fatal("setupTestDB returned a nil database")
+	}
+
+	app := &testApp{
+		App: App{
+			_db:   db,
+			dbMux: &sync.Mutex{},
+			logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		setupDB        func(*gorm.DB)
+		expectedErrMsg string
+	}{
+		{
+			name: "Process exists",
+			setupDB: func(db *gorm.DB) {
+				process := model.Process{ID: uuid.New()}
+				result := db.Create(&process)
+				if result.Error != nil {
+					t.Fatalf("Failed to create process: %v", result.Error)
+				}
+			},
+		},
+		{
+			name:           "Process does not exist",
+			setupDB:        func(db *gorm.DB) {},
+			expectedErrMsg: "process not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupDB(db)
+
+			// Use a fixed UUID for testing to ensure we're looking for the correct process
+			testUUID := uuid.New()
+			if tt.name == "Process exists" {
+				process := model.Process{ID: testUUID}
+				result := db.Create(&process)
+				if result.Error != nil {
+					t.Fatalf("Failed to create process: %v", result.Error)
+				}
+			}
+
+			err := app.validateProcessExists(context.Background(), testUUID)
+
+			if tt.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseAndValidateModelMetricsRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestBody    interface{}
+		expectedLen    int
+		expectedErrMsg string
+	}{
+		{
+			name: "Valid request",
+			requestBody: []modelMetricsRequest{
+				{
+					MetricName: "accuracy",
+					StepName:   "training",
+					Points: []struct {
+						Step  uint32 `json:"step"`
+						Value string `json:"value"`
+					}{
+						{Step: 1, Value: "0.75"},
+						{Step: 2, Value: "0.85"},
+					},
+				},
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "Invalid metric name",
+			requestBody: []modelMetricsRequest{
+				{
+					MetricName: "",
+					StepName:   "training",
+					Points: []struct {
+						Step  uint32 `json:"step"`
+						Value string `json:"value"`
+					}{{Step: 1, Value: "0.75"}},
+				},
+			},
+			expectedErrMsg: "metric name must be between 1 and 32 characters",
+		},
+		{
+			name: "Invalid step name",
+			requestBody: []modelMetricsRequest{
+				{
+					MetricName: "accuracy",
+					StepName:   "",
+					Points: []struct {
+						Step  uint32 `json:"step"`
+						Value string `json:"value"`
+					}{{Step: 1, Value: "0.75"}},
+				},
+			},
+			expectedErrMsg: "step name must be between 1 and 32 characters",
+		},
+		{
+			name: "Invalid step value",
+			requestBody: []modelMetricsRequest{
+				{
+					MetricName: "accuracy",
+					StepName:   "training",
+					Points: []struct {
+						Step  uint32 `json:"step"`
+						Value string `json:"value"`
+					}{{Step: 0, Value: "0.75"}},
+				},
+			},
+			expectedErrMsg: "step must be a positive number",
+		},
+		{
+			name: "Invalid metric value",
+			requestBody: []modelMetricsRequest{
+				{
+					MetricName: "accuracy",
+					StepName:   "training",
+					Points: []struct {
+						Step  uint32 `json:"step"`
+						Value string `json:"value"`
+					}{{Step: 1, Value: ""}},
+				},
+			},
+			expectedErrMsg: "metric value must be between 1 and 64 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(tt.requestBody)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest("POST", "/process/123/model-metrics", bytes.NewBuffer(body))
+			require.NoError(t, err)
+
+			result, err := parseAndValidateModelMetricsRequest(req)
+
+			if tt.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, result, tt.expectedLen)
+			}
+		})
+	}
+}

--- a/ai-training-api/app/model_metrics_test.go
+++ b/ai-training-api/app/model_metrics_test.go
@@ -264,3 +264,94 @@ func TestParseAndValidateModelMetricsRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMetrics(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	if db == nil {
+		t.Fatal("setupTestDB returned a nil database")
+	}
+
+	app := &testApp{
+		App: App{
+			_db:   db,
+			dbMux: &sync.Mutex{},
+			logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		setupDB        func(*gorm.DB) (uint64, uuid.UUID) // Modified to return stackID and processID
+		expectedSeries int
+		expectedErrMsg string
+	}{
+		{
+			name: "Multiple metrics for a single process",
+			setupDB: func(db *gorm.DB) (uint64, uuid.UUID) {
+				stackID := uint64(1)
+				processID := uuid.New()
+
+				metrics := []model.ModelMetrics{
+					{StackID: stackID, ProcessID: processID, MetricName: "cpu_usage", StepName: "step1", Step: 1, MetricValue: "10.0"},
+					{StackID: stackID, ProcessID: processID, MetricName: "cpu_usage", StepName: "step1", Step: 2, MetricValue: "20.0"},
+					{StackID: stackID, ProcessID: processID, MetricName: "memory_usage", StepName: "step1", Step: 1, MetricValue: "30.0"},
+				}
+				for _, metric := range metrics {
+					result := db.Create(&metric)
+					if result.Error != nil {
+						t.Fatalf("Failed to create model metrics: %v", result.Error)
+					}
+				}
+				return stackID, processID
+			},
+			expectedSeries: 2, // 2 unique (MetricName, StepName) pairs
+		},
+		{
+			name: "No metrics for process",
+			setupDB: func(db *gorm.DB) (uint64, uuid.UUID) {
+				stackID := uint64(1)
+				processID := uuid.New()
+				// No metrics inserted into the database
+				return stackID, processID
+			},
+			expectedSeries: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stackID, processID := tt.setupDB(db)
+
+			// Call the function under test
+			response, err := app.getMetricsForGrafana(context.Background(), stackID, processID)
+
+			if tt.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+
+				// Verify the response
+				series, ok := response["series"].([]map[string]interface{})
+				if !ok {
+					t.Fatalf("Expected 'series' to be a list of maps, got: %T", response["series"])
+				}
+
+				assert.Equal(t, tt.expectedSeries, len(series))
+
+				// Optionally, check the content of the series
+				if tt.expectedSeries > 0 {
+					for _, s := range series {
+						name := s["name"].(string)
+						points := s["points"].([][2]interface{})
+
+						// Ensure each series has at least one point
+						assert.NotEmpty(t, points, "Series %s should have points", name)
+					}
+				}
+			}
+		})
+	}
+}

--- a/ai-training-api/go.mod
+++ b/ai-training-api/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/dskit v0.0.0-20240411172511-de4086540f6f
 	github.com/jeremywohl/flatten/v2 v2.0.0-20211013061545-07e4a09fb8e4
+	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.52.3
 	github.com/stretchr/testify v1.9.0
@@ -43,7 +44,6 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.3 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e // indirect
 	github.com/opentracing-contrib/go-stdlib v1.0.0 // indirect
@@ -55,6 +55,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.10.1-0.20230714054209-2f4150c63f97 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sercand/kuberesolver/v5 v5.1.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/uber/jaeger-client-go v2.28.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect

--- a/ai-training-api/model/model_metrics.go
+++ b/ai-training-api/model/model_metrics.go
@@ -1,24 +1,20 @@
 package model
 
 import (
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
 type ModelMetrics struct {
-	// Unique identifier for the metric entry.
-	ID           uint   `json:"id" gorm:"primaryKey;autoIncrement"`
-	// Tenant ID is used to identify the tenant to which the metric belongs.
-	Tenant       string `json:"tenant" gorm:"size:255;not null"`
-	// Run ID is used to identify the specific run.
-	Run          string `json:"run" gorm:"size:255;not null"`
-	// The name of the metric.
-	MetricName   string `json:"metric_name" gorm:"size:255;not null"`
-	// Step represents the measurement step; unsigned integer.
-	Step         uint   `json:"step" gorm:"not null"`
-	// MetricValue stores the value of the metric as a string.
-	MetricValue  string `json:"metric_value" gorm:"size:255;not null"`
-}
+    StackID     uint64   `json:"stack_id" gorm:"not null;primaryKey"`
+    ProcessID   uuid.UUID `json:"process_id" gorm:"type:char(36);not null;primaryKey;foreignKey:ProcessID;references:ID"` // Foreign key
+    MetricName  string   `json:"metric_name" gorm:"size:32;not null;primaryKey"`
+    StepName    string   `json:"step_name" gorm:"size:32;not null;primaryKey"`
+    Step        uint32   `json:"step" gorm:"not null;primaryKey"`
+    MetricValue string   `json:"metric_value" gorm:"size:64;not null"`
 
+    Process Process `gorm:"foreignKey:ProcessID;references:ID"` // Relationship definition
+}
 // Add a custom hook if necessary for additional logic.
 // Example: AfterCreate hook for custom logic
 func (m *ModelMetrics) AfterCreate(tx *gorm.DB) error {

--- a/ai-training-api/model/model_metrics.go
+++ b/ai-training-api/model/model_metrics.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"gorm.io/gorm"
+)
+
+type ModelMetrics struct {
+	// Unique identifier for the metric entry.
+	ID           uint   `json:"id" gorm:"primaryKey;autoIncrement"`
+	// Tenant ID is used to identify the tenant to which the metric belongs.
+	Tenant       string `json:"tenant" gorm:"size:255;not null"`
+	// Run ID is used to identify the specific run.
+	Run          string `json:"run" gorm:"size:255;not null"`
+	// The name of the metric.
+	MetricName   string `json:"metric_name" gorm:"size:255;not null"`
+	// Step represents the measurement step; unsigned integer.
+	Step         uint   `json:"step" gorm:"not null"`
+	// MetricValue stores the value of the metric as a string.
+	MetricValue  string `json:"metric_value" gorm:"size:255;not null"`
+}
+
+// Add a custom hook if necessary for additional logic.
+// Example: AfterCreate hook for custom logic
+func (m *ModelMetrics) AfterCreate(tx *gorm.DB) error {
+	// Custom logic after creating a metric entry
+	tx.Logger.Info(tx.Statement.Context, "AfterCreate hook called for ModelMetrics")
+	return nil
+}


### PR DESCRIPTION
WIP

Meant to transition writing and reading model metrics from loki to mysql, currently has a writer implemented and the reader function is there but not attached to an endpoint.

TODO for this:

- [ ] make sure the reader function works, and serves an endpoint
- [ ] have the UI query that endpoint instead of loki
- [ ] switch the python client to write to this (format was changed slightly to allow for debouncing so that we don't end up with too many http connections open at once for frequent logging jobs)