### PR TITLE
Create instructions for sending data

### DIFF
--- a/grafana-aitraining-app/pkg/plugin/app.go
+++ b/grafana-aitraining-app/pkg/plugin/app.go
@@ -25,11 +25,11 @@ var (
 // App is an example app backend plugin which can respond to data queries.
 type App struct {
 	backend.CallResourceHandler
-	lokiDatasourceName string
+	lokiDatasourceName  string
 	mimirDatasourceName string
-	metadataUrl string
-	metadataToken string
-	stackId string
+	metadataURL         string
+	metadataToken       string
+	stackID             string
 }
 
 func NewApp(_ context.Context, appSettings backend.AppInstanceSettings) (instancemgmt.Instance, error) {
@@ -58,8 +58,8 @@ func NewApp(_ context.Context, appSettings backend.AppInstanceSettings) (instanc
 	}
 
 	// Set values from JSONData
-	app.metadataUrl = getStringValue("metadataUrl")
-	app.stackId = getStringValue("stackId")
+	app.metadataURL = getStringValue("metadataUrl")
+	app.stackID = getStringValue("stackId")
 	app.lokiDatasourceName = getStringValue("lokiDatasourceName")
 	app.mimirDatasourceName = getStringValue("mimirDatasourceName")
 

--- a/grafana-aitraining-app/pkg/plugin/app_test.go
+++ b/grafana-aitraining-app/pkg/plugin/app_test.go
@@ -82,8 +82,8 @@ func TestNewApp(t *testing.T) {
 			app, ok := instance.(*App)
 			require.True(t, ok)
 
-			assert.Equal(t, tt.expected["metadataUrl"], app.metadataUrl)
-			assert.Equal(t, tt.expected["stackId"], app.stackId)
+			assert.Equal(t, tt.expected["metadataUrl"], app.metadataURL)
+			assert.Equal(t, tt.expected["stackId"], app.stackID)
 			assert.Equal(t, tt.expected["lokiDatasourceName"], app.lokiDatasourceName)
 			assert.Equal(t, tt.expected["mimirDatasourceName"], app.mimirDatasourceName)
 			assert.Equal(t, tt.expected["metadataToken"], app.metadataToken)
@@ -120,8 +120,8 @@ func TestNewAppWithNonStringValues(t *testing.T) {
 	app, ok := instance.(*App)
 	require.True(t, ok)
 
-	assert.Empty(t, app.metadataUrl)
-	assert.Empty(t, app.stackId)
+	assert.Empty(t, app.metadataURL)
+	assert.Empty(t, app.stackID)
 	assert.Empty(t, app.lokiDatasourceName)
 	assert.Empty(t, app.mimirDatasourceName)
 }

--- a/grafana-aitraining-app/pkg/plugin/resources.go
+++ b/grafana-aitraining-app/pkg/plugin/resources.go
@@ -81,13 +81,13 @@ func (a *App) metadataHandler(target string) func(http.ResponseWriter, *http.Req
 		}
 
 		// Set Authorization header if token is available
-		if a.metadataToken != "" && a.stackId != "" {
-			req.Header.Set("Authorization", "Bearer "+ a.stackId + ":" + a.metadataToken)
+		if a.metadataToken != "" && a.stackID != "" {
+			req.Header.Set("Authorization", "Bearer "+a.stackID+":"+a.metadataToken)
 		}
 
-		log.DefaultLogger.Debug("Proxying metadata request", 
-			"method", req.Method, 
-			"url", req.URL.String(), 
+		log.DefaultLogger.Debug("Proxying metadata request",
+			"method", req.Method,
+			"url", req.URL.String(),
 			"host", req.Host,
 			"x-forwarded-host", req.Header.Get("X-Forwarded-Host"))
 	}
@@ -103,6 +103,6 @@ func (a *App) registerRoutes(mux *http.ServeMux) {
 	log.DefaultLogger.Info("Registering routes")
 	mux.HandleFunc("/ping", a.handlePing)
 	mux.HandleFunc("/echo", a.handleEcho)
-	mux.HandleFunc("/metadata/", a.metadataHandler(a.metadataUrl)) // Use config for this
+	mux.HandleFunc("/metadata/", a.metadataHandler(a.metadataURL)) // Use config for this
 	log.DefaultLogger.Info("Routes registered successfully")
 }

--- a/grafana-aitraining-app/pkg/plugin/resources_test.go
+++ b/grafana-aitraining-app/pkg/plugin/resources_test.go
@@ -57,7 +57,7 @@ func TestCallResource(t *testing.T) {
 	defer testServer.Close()
 
 	// Update the app's metadataUrl to point to our test server
-	app.metadataUrl = testServer.URL
+	app.metadataURL = testServer.URL
 
 	// Set up and run test cases
 	testCases := []struct {
@@ -134,9 +134,9 @@ func TestCallResource(t *testing.T) {
 
 func TestMetadataHandlerTokenInjection(t *testing.T) {
 	app := &App{
-		metadataUrl:   "http://example.com",
+		metadataURL:   "http://example.com",
 		metadataToken: "test-token",
-		stackId:       "test-stack-id",
+		stackID:       "test-stack-id",
 	}
 
 	// Create a test server to mock the metadata service
@@ -150,17 +150,17 @@ func TestMetadataHandlerTokenInjection(t *testing.T) {
 	defer testServer.Close()
 
 	// Update the app's metadataUrl to point to our test server
-	app.metadataUrl = testServer.URL
+	app.metadataURL = testServer.URL
 
 	// Create a test request
 	req := httptest.NewRequest("GET", "/metadata/test", nil)
-	req.Host = "test-host"  // Set the Host header
+	req.Host = "test-host" // Set the Host header
 
 	// Create a response recorder
 	rr := httptest.NewRecorder()
 
 	// Call the metadataHandler
-	handler := app.metadataHandler(app.metadataUrl)
+	handler := app.metadataHandler(app.metadataURL)
 	handler(rr, req)
 
 	// Check the response
@@ -178,9 +178,9 @@ func TestMetadataHandlerTokenInjection(t *testing.T) {
 
 func TestMetadataHandlerPathTransformations(t *testing.T) {
 	app := &App{
-		metadataUrl:   "http://example.com",
+		metadataURL:   "http://example.com",
 		metadataToken: "test-token",
-		stackId:       "test-stack-id",
+		stackID:       "test-stack-id",
 	}
 
 	testCases := []struct {
@@ -211,17 +211,17 @@ func TestMetadataHandlerPathTransformations(t *testing.T) {
 			defer testServer.Close()
 
 			// Update the app's metadataUrl to point to our test server
-			app.metadataUrl = testServer.URL
+			app.metadataURL = testServer.URL
 
 			// Create a test request
 			req := httptest.NewRequest("GET", tc.inputPath, nil)
-			req.Host = "test-host"  // Set the Host header
+			req.Host = "test-host" // Set the Host header
 
 			// Create a response recorder
 			rr := httptest.NewRecorder()
 
 			// Call the metadataHandler
-			handler := app.metadataHandler(app.metadataUrl)
+			handler := app.metadataHandler(app.metadataURL)
 			handler(rr, req)
 
 			// Check the response
@@ -241,7 +241,7 @@ func TestMetadataHandlerPathTransformations(t *testing.T) {
 
 func TestMetadataHandlerNoToken(t *testing.T) {
 	app := &App{
-		metadataUrl: "http://example.com",
+		metadataURL: "http://example.com",
 		// No token set
 	}
 
@@ -258,7 +258,7 @@ func TestMetadataHandlerNoToken(t *testing.T) {
 	defer testServer.Close()
 
 	// Update the app's metadataUrl to point to our test server
-	app.metadataUrl = testServer.URL
+	app.metadataURL = testServer.URL
 
 	// Helper function to create and send a request
 	sendRequest := func(t *testing.T, path string, headers map[string]string) *httptest.ResponseRecorder {
@@ -268,7 +268,7 @@ func TestMetadataHandlerNoToken(t *testing.T) {
 			req.Header.Set(key, value)
 		}
 		rr := httptest.NewRecorder()
-		handler := app.metadataHandler(app.metadataUrl)
+		handler := app.metadataHandler(app.metadataURL)
 		handler(rr, req)
 		return rr
 	}
@@ -283,7 +283,7 @@ func TestMetadataHandlerNoToken(t *testing.T) {
 	// Test case 2: Request with multiple custom headers
 	t.Run("Multiple Custom Headers", func(t *testing.T) {
 		headers := map[string]string{
-			"X-Custom-Header": "preserved-value",
+			"X-Custom-Header":       "preserved-value",
 			"Another-Custom-Header": "another-value",
 		}
 		rr := sendRequest(t, "/metadata/test", headers)

--- a/grafana-aitraining-app/src/hooks/useProcessQueries.tsx
+++ b/grafana-aitraining-app/src/hooks/useProcessQueries.tsx
@@ -1,20 +1,9 @@
 import { useTrainingAppStore } from 'utils/state';
 import { runQuery } from 'utils/runQuery';
 import { dateTime, TimeRange } from '@grafana/data';
-import { FetchResponse, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
-import { lastValueFrom } from 'rxjs';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { useAsync } from 'react-use';
-
-export const getSettings = async (pluginId: string) => {
-  const response = getBackendSrv().fetch({
-    url: `/api/plugins/${pluginId}/settings`,
-    method: 'get',
-  });
-
-  const dataResponse = await lastValueFrom(response);
-  const { lokiDatasourceName, mimirDatasourceName, metadataUrl } = (dataResponse as FetchResponse<any>).data.jsonData;
-  return { lokiDatasourceName, mimirDatasourceName, metadataUrl };
-}
+import { getSettings } from './useSettings';
 
 const useProcessQueries = () => {
   let datasource: any = null;

--- a/grafana-aitraining-app/src/hooks/useSettings.tsx
+++ b/grafana-aitraining-app/src/hooks/useSettings.tsx
@@ -1,0 +1,31 @@
+import { FetchResponse, getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+import { useAsync } from 'react-use';
+
+export const getSettings = async (pluginId: string) => {
+  const response = getBackendSrv().fetch({
+    url: `/api/plugins/${pluginId}/settings`,
+    method: 'get',
+  });
+
+  const dataResponse = await lastValueFrom(response);
+  const { lokiDatasourceName, mimirDatasourceName, metadataUrl, stackId } = (dataResponse as FetchResponse<any>).data.jsonData;
+  return { lokiDatasourceName, mimirDatasourceName, metadataUrl, stackId };
+}
+
+export const useSettings = () => {
+  const fetchSettings = async () => {
+    try {
+      return await getSettings('grafana-aitraining-app');
+    } catch (error) {
+      console.error('Error getting datasource settings:', error);
+      throw error;
+    }
+  };
+  const settings = useAsync(fetchSettings, []);
+  return {
+    isReady: settings.loading !== true,
+    settings: settings.value,
+    error: settings.error,
+  }
+}

--- a/grafana-aitraining-app/src/utils/state.ts
+++ b/grafana-aitraining-app/src/utils/state.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { PanelData } from '@grafana/data';
 
+export type ConfigStatus = 'loading' | 'success' | 'error';
 export type ProcessStatus = 'empty' | 'running' | 'finished' | 'crashed' | 'timed out';
 export type QueryStatus =
   | 'idle'


### PR DESCRIPTION
An initial pass at populating the credential string for sending data to the metadata server. There are slightly different paths for cloud vs local right now.

Needs some small improvements to the UI, such as making the link actually look like a link...