### PR TITLE
Use a URL rather than custom format for client

### DIFF
--- a/.config/grafana/plugins/app.yaml
+++ b/.config/grafana/plugins/app.yaml
@@ -9,5 +9,6 @@ apps:
       metadataUrl: http://ai-training-api:8000
       lokiDatasourceName: Loki
       mimirDatasourceName: Mimir
+      stackId: "1"
     secureJsonData:
       metadataToken: secret-key

--- a/docker-compose-jupyter.yml
+++ b/docker-compose-jupyter.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8888:8888"
     environment:
-      - GF_AI_TRAINING_CREDS=83bcaff6228b39bbe431af5e19fb4368e2a03dd3:1337@http://ai-training-api:8000
+      - GF_AI_TRAINING_CREDS=http://1337:83bcaff6228b39bbe431af5e19fb4368e2a03dd3@ai-training-api:8000
 
 networks:
   shared-network:

--- a/docker-compose-pytorch.yml
+++ b/docker-compose-pytorch.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8888:8888"
     environment:
-      - GF_AI_TRAINING_CREDS=83bcaff6228b39bbe431af5e19fb4368e2a03dd3:1337@http://ai-training-api:8000
+      - GF_AI_TRAINING_CREDS=http://1337:83bcaff6228b39bbe431af5e19fb4368e2a03dd3@ai-training-api:8000
 
 networks:
   shared-network:

--- a/grafana-aitraining-app/src/pages/Home/Home.tsx
+++ b/grafana-aitraining-app/src/pages/Home/Home.tsx
@@ -100,6 +100,14 @@ export const Home = () => {
     return <Alert title="Error loading"> Error loading app settings. Please try again later. </Alert>;
   }
 
+  const isCloud = settings.stackId !== undefined && settings.stackId !== '';
+  let metadataUrl = new URL(settings.metadataUrl);
+  if (isCloud) {
+    metadataUrl.username = settings.stackId
+    // Setting the password appears to pass through URL encoding still so <token> is not rendered properly.
+    metadataUrl.password = '--token--'
+  }
+
   return (
     <PluginPage
       renderTitle={() => {
@@ -117,23 +125,18 @@ export const Home = () => {
               Select one or more training processes from the list below.
               <br />
               Then, click <strong>View graphs</strong> and a list of graphs will be generated.
-              <div>
+              <p>
                 To send data to the AI Training o11y app set the following environment variable:
-                {settings.stackId === undefined || settings.stackId === '' ? (
-                  <pre>
-                    GF_AI_TRAINING_CREDS={settings.metadataUrl}
-                  </pre>
-                ) : (<pre>
-                  GF_AI_TRAINING_CREDS={"<token>"}:{settings.stackId}@{settings.metadataUrl}
-                </pre>
-                )}
-                {settings.stackId !== undefined && settings.stackId !== '' ? (
-                  // Only generate this section if a stackId is present (running in cloud).
-                  <p>
-                    To generate a token create an access policy in the <TextLink href="/a/grafana-auth-app">Grafana auth app</TextLink>.
-                  </p>
-                ) : null}
-              </div>
+              </p>
+              <pre>
+                {'GF_AI_TRAINING_CREDS="' + metadataUrl + '"'}
+              </pre>
+              {isCloud ? (
+                // Only generate this section if a stackId is present (running in cloud).
+                <p>
+                  To generate a token create an access policy in the <TextLink href="/a/grafana-auth-app">Grafana auth app</TextLink>.
+                </p>
+              ) : null}
             </div>
             {selectedRows.length < 1 ? (
               <Button disabled={true} variant="primary">


### PR DESCRIPTION
Rather than parsing out a custom format for the environment variable use standard URL parsing in conjunction with basic auth. Basic or bearer auth are both supported by Grafana Cloud and this will also allow open source users to setup basic auth for their environments.